### PR TITLE
Freebase was shut down in 2016.

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,8 +294,6 @@ The following websites are fully integrated with ZXDB:
 
 * [Lost in Translation](http://www.exotica.org.uk/) - Each ZXDB title links to the corresponding webpage at Lost in Translation.
 
-* [Freebase](http://zxspectrum.freebase.com/) - Each ZXDB title links to the corresponding webpage at Freebase.
-
 * [The Tipshop](http://www.the-tipshop.co.uk/) - Each ZXDB title links to the corresponding webpage at **Gerard Sweeney**'s site.
 
 * [WorldOfSpectrum](http://www.worldofspectrum.org/) - Each ZXDB title links to the corresponding webpage at **Martijn van der Heide**'s site.


### PR DESCRIPTION
There is in theory still the [data dump](https://developers.google.com/freebase/) available but it's not really useful for very much so I'd suggest just dropping the link.